### PR TITLE
 Removing code that sets credentials on sharedSession on app launching

### DIFF
--- a/Drupal8iOS/AppDelegate.m
+++ b/Drupal8iOS/AppDelegate.m
@@ -31,19 +31,6 @@ int d8FlagLevel = D8FLAGDEBUG; // MAS: highest level
     
     [sharedSession setBaseURL:[NSURL URLWithString:[defaults objectForKey:@"drupal8site"]?:@""]];
     
-    NSError *error = nil;
-    
-    NSArray *credentials  = [SGKeychain usernamePasswordForServiceName:@"Drupal 8" accessGroup:nil error:&error];
-    // First element of the array is user name
-    // Second element is the password
-    
-    if (credentials !=nil && credentials[0] != nil) {
-        
-        // Here we perform a network call and verify the credentials --
-        [sharedSession setBasicAuthCredsWithUsername:credentials[0] andPassword:credentials[1]];
-        
-    }
-    
     UISplitViewController *splitViewController = (UISplitViewController *)self.window.rootViewController;
     UINavigationController *navigationController = [splitViewController.viewControllers lastObject];
     navigationController.topViewController.navigationItem.leftBarButtonItem = splitViewController.displayModeButtonItem;


### PR DESCRIPTION
Removing code that sets credentials on sharedSession on app launching as it created problem with some screen. Actually when I wrote that code I have intention to hide some screens that should not be visible to logged in user like "Setup new account" but as currently it has not been implemented , setting the credentials on shared session created problem. So please remove it for now when screen hiding feature will be implemented then it can be rewritten.
Sorry for last moment changes.

Sincerely,
Vivek 
